### PR TITLE
Update Edge.java

### DIFF
--- a/Edge.java
+++ b/Edge.java
@@ -74,9 +74,7 @@ class EdgePair implements Comparable<EdgePair>
 
     public int compareTo(EdgePair ep)
     {
-        if(Math.abs(this.error - ep.error) > 10e-15)
-            return (this.error - ep.error)>0 ? 1 : -1;
-        return e.hashCode() - ep.hashCode(); //random
+        return (this.error - ep.error)>0 ? 1 : -1;
     }
 
     public boolean equals(Object o)


### PR DESCRIPTION
If you're ok with a random choice for pairs which differ less than 10e-15, then you could just as well let ```(this.error - ep.error)>0``` decide. Couldn't be worse than random, right? Plus: it's a deterministic choice.