### PR TITLE
Memory usage optimization

### DIFF
--- a/Simplifier.java
+++ b/Simplifier.java
@@ -169,6 +169,7 @@ public class Simplifier
 
                 ep.isRemoved = true;
                 edgeQueue.remove(ep); //logn
+                edgeMap.remove(ep.edge);
                 if(!v1.equals(v2)){
                     Edge newE = new Edge(v1, v2);
                     if(!edgeMap.containsKey(newE)){


### PR DESCRIPTION
When deleted edges are not removed from edgeMap but newly created edges keep being added then memory consumption is growing continuously. This causes program crashes due to heap overflow when processing very big models. I tested this with models of 1.5 Million faces noticed a change in memory usage of -60% after this patch.